### PR TITLE
Add map UI for choosing criterion locations

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,12 +2,40 @@ from flask import Flask, request, jsonify, send_file
 import pandas as pd
 from datetime import datetime
 import os
+import numpy as np
+from pymcdm.methods import SPOTIS
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 DATA_DIR = os.path.join(BASE_DIR, "data")
 os.makedirs(DATA_DIR, exist_ok=True)
 
+
 app = Flask(__name__)
+
+def haversine(lat1, lon1, lat2, lon2):
+    R = 6371.0
+    p1 = np.radians([lat1, lon1])
+    p2 = np.radians([lat2, lon2])
+    dlat, dlon = p2 - p1
+    a = np.sin(dlat/2)**2 + np.cos(p1[0])*np.cos(p2[0])*np.sin(dlon/2)**2
+    c = 2 * np.arctan2(np.sqrt(a), np.sqrt(1-a))
+    return R * c
+
+def rancom_weights(criteria, pairwise):
+    counts = {c: 0.0 for c in criteria}
+    for key, val in pairwise.items():
+        c1, c2 = key.split('_')
+        if val == c1:
+            counts[c1] += 1
+        elif val == c2:
+            counts[c2] += 1
+        else:  # equal
+            counts[c1] += 0.5
+            counts[c2] += 0.5
+    total = sum(counts.values())
+    if total == 0:
+        return np.ones(len(criteria)) / len(criteria)
+    return np.array([counts[c]/total for c in criteria])
 
 @app.route('/')
 def index():
@@ -19,6 +47,7 @@ def save_points():
     data = request.get_json()
     points = data.get('points', [])
     criteria = data.get('criteria', [])
+    locations = data.get('locations', {})
     
     # Save points
     df_points = pd.DataFrame(points)
@@ -26,18 +55,60 @@ def save_points():
     points_filename = os.path.join(DATA_DIR, f"points_{timestamp}.csv")
     df_points.to_csv(points_filename, index=False)
     
-    # Save criteria
-    df_criteria = pd.DataFrame({'criteria': criteria})
+    # Save criteria with locations if provided
+    records = []
+    for c in criteria:
+        loc = locations.get(c, {})
+        records.append({
+            'criteria': c,
+            'latitude': loc.get('latitude'),
+            'longitude': loc.get('longitude')
+        })
+    df_criteria = pd.DataFrame(records)
     criteria_filename = os.path.join(DATA_DIR, f"criteria_{timestamp}.csv")
     df_criteria.to_csv(criteria_filename, index=False)
     
     print(f"Saved {len(points)} points and {len(criteria)} criteria")
-    
+
     return jsonify({
-        'success': True, 
+        'success': True,
         'filename': os.path.basename(points_filename),
         'criteria_file': os.path.basename(criteria_filename)
     })
+
+
+@app.route('/rank', methods=['POST'])
+def rank_points():
+    data = request.get_json()
+    points = data.get('points', [])
+    criteria = data.get('criteria', [])
+    pairwise = data.get('pairwise', {})
+    locations = data.get('locations', {})
+
+    if not points or not criteria:
+        return jsonify({'success': False, 'error': 'No data'}), 400
+
+    weights = rancom_weights(criteria, pairwise)
+
+    matrix = []
+    for p in points:
+        lat = p['latitude']
+        lon = p['longitude']
+        row = []
+        for c in criteria:
+            loc = locations.get(c)
+            if loc:
+                row.append(haversine(lat, lon, loc['latitude'], loc['longitude']))
+            else:
+                row.append(0.0)
+        matrix.append(row)
+    matrix = np.array(matrix)
+    types = np.array([-1]*len(criteria))
+    bounds = SPOTIS.make_bounds(matrix)
+    spotis = SPOTIS(bounds)
+    prefs = spotis(matrix, weights, types)
+    ranking = list(np.argsort(prefs) + 1)
+    return jsonify({'success': True, 'weights': weights.tolist(), 'ranking': ranking})
 
 if __name__ == '__main__':
     app.run(debug=True,host='0.0.0.0', port=5000)

--- a/index.html
+++ b/index.html
@@ -49,7 +49,10 @@
     <div id="step2" class="step">
         <h1>Pairwise Comparison</h1>
         <div id="selected-criteria"></div>
-        <p>Here you will implement RANCOM pairwise comparison</p>
+        <div id="pairwise-container"></div>
+        <h2>Criterion Locations</h2>
+        <div id="locations-container"></div>
+        <div id="criteria-map" style="height:400px;margin-top:10px"></div>
         <button onclick="goToStep3()">Next: Select Points on Map</button>
     </div>
 
@@ -58,39 +61,105 @@
         <h1>Select Points</h1>
         <button onclick="clearPoints()">Clear</button>
         <button onclick="savePoints()">Save to CSV</button>
+        <button onclick="rankPoints()">Rank Points</button>
         <span id="pointCount">Points: 0</span>
         <div id="map"></div>
         <div id="status"></div>
+        <div id="ranking"></div>
     </div>
 
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script>
         let selectedCriteria = [];
+        let pairwise = {};
+        let criteriaLocations = {};
         let points = [];
         let markers = [];
         let map;
+        let criteriaMap;
+        let criteriaMarkers = {};
+        let currentCriterion = null;
+
+        function initCriteriaMap() {
+            if (criteriaMap) {
+                setTimeout(() => criteriaMap.invalidateSize(), 100);
+                return;
+            }
+            criteriaMap = L.map('criteria-map').setView([52.2297, 21.0122], 12);
+            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                attribution: '© OpenStreetMap contributors'
+            }).addTo(criteriaMap);
+
+            criteriaMap.on('click', function(e) {
+                if(currentCriterion){
+                    if(criteriaMarkers[currentCriterion]){
+                        criteriaMap.removeLayer(criteriaMarkers[currentCriterion]);
+                    }
+                    const marker = L.marker(e.latlng).addTo(criteriaMap);
+                    criteriaMarkers[currentCriterion] = marker;
+                    criteriaLocations[currentCriterion] = {latitude: e.latlng.lat, longitude: e.latlng.lng};
+                    document.getElementById(`loc-${currentCriterion}-txt`).textContent = `${e.latlng.lat.toFixed(6)}, ${e.latlng.lng.toFixed(6)}`;
+                    currentCriterion = null;
+                }
+            });
+        }
+
+        function startSetLocation(c){
+            currentCriterion = c;
+            alert('Click on the map to set location for ' + c);
+        }
 
         // Step 1 to 2
         function goToStep2() {
             const checkboxes = document.querySelectorAll('input[type="checkbox"]:checked');
             selectedCriteria = Array.from(checkboxes).map(cb => cb.value);
-            
-            document.getElementById('selected-criteria').innerHTML = 
+
+            document.getElementById('selected-criteria').innerHTML =
                 '<p>Selected: ' + selectedCriteria.join(', ') + '</p>';
-            
+            const container = document.getElementById('pairwise-container');
+            container.innerHTML = '';
+            const locContainer = document.getElementById('locations-container');
+            locContainer.innerHTML = '';
+            pairwise = {};
+            criteriaLocations = {};
+            criteriaMarkers = {};
+            for (let i = 0; i < selectedCriteria.length; i++) {
+                for (let j = i + 1; j < selectedCriteria.length; j++) {
+                    const c1 = selectedCriteria[i];
+                    const c2 = selectedCriteria[j];
+                    const div = document.createElement('div');
+                    div.innerHTML = `${c1} vs ${c2}: ` +
+                        `<label><input type="radio" name="${c1}_${c2}" value="${c1}"> ${c1}</label>` +
+                        `<label><input type="radio" name="${c1}_${c2}" value="equal"> = </label>` +
+                        `<label><input type="radio" name="${c1}_${c2}" value="${c2}"> ${c2}</label>`;
+                    container.appendChild(div);
+                }
+            }
+
+            selectedCriteria.forEach(c => {
+                const div = document.createElement('div');
+                div.innerHTML = `${c}: <span id="loc-${c}-txt">Not set</span> ` +
+                                 `<button onclick="startSetLocation('${c}')">Set on Map</button>`;
+                locContainer.appendChild(div);
+            });
+            initCriteriaMap();
+
             showStep(2);
         }
 
         // Step 2 to 3
         function goToStep3() {
-            showStep(3); // Najpierw pokaż kontener
-            if (!map) { // Inicjalizuj mapę tylko jeśli jeszcze nie istnieje
+            document.querySelectorAll('#pairwise-container input[type="radio"]:checked').forEach(r => {
+                const key = r.name;
+                pairwise[key] = r.value;
+            });
+            // locations already filled via map clicks
+            currentCriterion = null;
+            showStep(3);
+            if (!map) {
                 initMap();
             } else {
-                // Jeśli mapa już była, a tylko krok był zmieniany
-                setTimeout(function() {
-                    map.invalidateSize();
-                }, 100);
+                setTimeout(function() { map.invalidateSize(); }, 100);
             }
         }
 
@@ -161,15 +230,37 @@
             fetch('/save', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ 
+                body: JSON.stringify({
                     points: points,
-                    criteria: selectedCriteria 
+                    criteria: selectedCriteria,
+                    locations: criteriaLocations
                 })
             })
             .then(response => response.json())
             .then(data => {
-                document.getElementById('status').textContent = 
+                document.getElementById('status').textContent =
                     data.success ? `Saved to ${data.filename}` : `Error: ${data.error}`;
+            });
+        }
+
+        function rankPoints() {
+            fetch('/rank', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    points: points,
+                    criteria: selectedCriteria,
+                    pairwise: pairwise,
+                    locations: criteriaLocations
+                })
+            })
+            .then(r => r.json())
+            .then(data => {
+                if(data.success){
+                    document.getElementById('ranking').textContent = 'Ranking: ' + data.ranking.join(', ');
+                } else {
+                    document.getElementById('ranking').textContent = 'Error ranking points';
+                }
             });
         }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask>=2.0
 pandas>=1.0
+pymcdm>=1.2


### PR DESCRIPTION
## Summary
- add dedicated map in step 2 for selecting locations associated with criteria
- store markers for each criterion and update text on selection
- ensure pairwise rankings use these map-chosen locations

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68418d9d4e10832d814a296d96e92358